### PR TITLE
rtmlamp: fix unresponsive state in Current-SP.

### DIFF
--- a/utcaApp/Db/fofb_processing_channel.template
+++ b/utcaApp/Db/fofb_processing_channel.template
@@ -57,8 +57,10 @@ record(longin, "$(S)$(RTM_CHAN)CurrentRawRefPassive"){
 record(calcout, "$(S)$(RTM_CHAN)OpModeHelperCopyCurrent"){
     field(SCAN, "Passive")
     field(INPA, "$(S)$(RTM_CHAN)CurrentRawRefPassive PP")
-    field(CALC, "A")
-    field(OUT, "$(S)$(RTM_CHAN)CurrentRaw-SP PP")
+    field(INPB,"$(S)$(RTM_CHAN)CurrGain-SP")
+    field(INPC,"$(S)$(RTM_CHAN)CurrOffset-SP")
+    field(CALC,"B*(A-C)")
+    field(OUT, "$(S)$(RTM_CHAN)Current-SP PP")
 }
 
 # set ps mode + (possibly) resume accumulator happens for both!

--- a/utcaApp/Db/rtmlamp_channel.template
+++ b/utcaApp/Db/rtmlamp_channel.template
@@ -268,15 +268,6 @@ record(longin,"$(S)$(RTM_CHAN)CurrentRaw-RB"){
     field(INP,"@asyn($(PORT),$(ADDR))PI_SP")
 }
 
-record(calcout,"$(S)$(RTM_CHAN)CurrentRawPropagateSP"){
-    field(SCAN,"Passive")
-    field(INPA,"$(S)$(RTM_CHAN)CurrentRaw-SP CP")
-    field(INPB,"$(S)$(RTM_CHAN)CurrGain-SP")
-    field(INPC,"$(S)$(RTM_CHAN)CurrOffset-SP")
-    field(CALC,"B*(A-C)")
-    field(OUT,"$(S)$(RTM_CHAN)Current-SP NPP")
-}
-
 record(calc,"$(S)$(RTM_CHAN)Current-RB"){
     field(DESC,"get manual current control")
     field(EGU, "A")


### PR DESCRIPTION
After a transition from "fofb" to "manual" in OpMode-Sel happened, we observed that the Current-SP record wouldn't process when a new value was first written to it (so the new current wouldn't be written to hardware via CurrentRaw-SP), nor would it be processed if one tried to write that same value again; it was necessary to write a different value altogether to force it to be processed.

This issue seems to have been caused by the logic which propagates the value written in CurrentRaw-SP to Current-SP. To avoid complicating any such logic even further, we have decided that the possibility of a small precision error happening when converting the ref current to amperes is not a big problem (the error would be small, and definitely below the noise threshold of the ADC anyway), so now we write through Current-SP directly, and there's no need to deal with complicated record logic.

@anacso17