### PR TITLE
udriver: update for uHAL API change.

### DIFF
--- a/utcaApp/src/fofb_processing.cpp
+++ b/utcaApp/src/fofb_processing.cpp
@@ -68,9 +68,9 @@ class FofbProcessing: public UDriver {
         read_parameters();
     }
 
-    asynStatus read_parameters()
+    asynStatus read_parameters(bool only_monitors=false)
     {
-        UDriver::read_parameters();
+        UDriver::read_parameters(only_monitors);
 
         for (unsigned addr = 0; addr < ::number_of_channels; addr++)
             setDoubleParam(addr, p_acc_gain, dec.get_channel_data<double>("CH_ACC_GAIN", addr));

--- a/utcaApp/src/sysid.cpp
+++ b/utcaApp/src/sysid.cpp
@@ -55,9 +55,9 @@ class SysId: public UDriver {
         read_parameters();
     }
 
-    asynStatus read_parameters()
+    asynStatus read_parameters(bool only_monitors=false)
     {
-        UDriver::read_parameters();
+        UDriver::read_parameters(only_monitors);
 
         for (unsigned addr = 0; addr < number_of_channels; addr++) {
             setIntegerParam(addr, p_setpoint_distortion_lvl0, dec.setpoint_distortion.prbs_0.at(addr));

--- a/utcaApp/src/udriver.h
+++ b/utcaApp/src/udriver.h
@@ -71,9 +71,9 @@ class UDriver: public asynPortDriver {
         create_params(name_and_index_channel, first_channel_parameter, last_channel_parameter);
     }
 
-    virtual asynStatus read_parameters()
+    virtual asynStatus read_parameters(bool only_monitors=false)
     {
-        generic_decoder->read();
+        generic_decoder->get_data(only_monitors);
 
         auto get_params = [this](auto first_param, auto last_param, auto fn) {
             if (first_param < 0) return;
@@ -119,7 +119,7 @@ class UDriver: public asynPortDriver {
 
         if (function == p_scan_task) {
             *value = scan_counter++;
-            return read_parameters();
+            return read_parameters(true);
         }
         else return asynPortDriver::readInt32(pasynUser, value);
     }


### PR DESCRIPTION
Use fast_get_data() for scan_task reads, since they are only monitoring values which change by themselves.

Depends on https://github.com/lnls-dig/uhal/pull/24