### PR TITLE
afc_timing: add new clock lock values.

### DIFF
--- a/utcaApp/Db/afc_timing.template
+++ b/utcaApp/Db/afc_timing.template
@@ -39,16 +39,51 @@ record(mbbi, "$(P)$(R)RxEnStatus-Mon"){
     field(ONST,"on")
 }
 
-record(mbbi, "$(P)$(R)RefClkLocked-Mon"){
+record(bi, "$(P)$(R)RefClkLocked-Mon"){
     field(DTYP, "asynInt32")
-    field(DESC, "Get Ref. Clock Locked Status")
+    field(DESC, "AFC Clock Locked Status")
     field(SCAN,"I/O Intr")
     field(INP,"@asyn($(PORT))STA_REFCLKLOCK")
-    field(NOBT,"1")
-    field(ZRVL,"0")
-    field(ONVL,"1")
-    field(ZRST,"off")
-    field(ONST,"on")
+    alias("$(P)$(R)AFCClkLocked-Mon")
+}
+record(bi, "$(P)$(R)RTMClkLocked-Mon"){
+    field(DTYP, "asynInt32")
+    field(DESC, "RTM Clock Locked Status")
+    field(SCAN,"I/O Intr")
+    field(INP,"@asyn($(PORT))STA_LOCKED_RTM")
+}
+record(bi, "$(P)$(R)GT0ClkLocked-Mon"){
+    field(DTYP, "asynInt32")
+    field(DESC, "GT0 Clock Locked Status")
+    field(SCAN,"I/O Intr")
+    field(INP,"@asyn($(PORT))STA_LOCKED_GT0")
+}
+record(bi, "$(P)$(R)AFCClkLockedLtc-Mon"){
+    field(DTYP, "asynInt32")
+    field(DESC, "AFC Latched Clock Locked Status")
+    field(SCAN,"I/O Intr")
+    field(INP,"@asyn($(PORT))STA_LOCKED_AFC_LATCH")
+}
+record(bi, "$(P)$(R)RTMClkLockedLtc-Mon"){
+    field(DTYP, "asynInt32")
+    field(DESC, "RTM Latched Clock Locked Status")
+    field(SCAN,"I/O Intr")
+    field(INP,"@asyn($(PORT))STA_LOCKED_RTM_LATCH")
+}
+record(bi, "$(P)$(R)GT0ClkLockedLtc-Mon"){
+    field(DTYP, "asynInt32")
+    field(DESC, "GT0 Latched Clock Locked Status")
+    field(SCAN,"I/O Intr")
+    field(INP,"@asyn($(PORT))STA_LOCKED_GT0_LATCH")
+}
+record(bo, "$(P)$(R)LtcRst-Cmd"){
+  field(DTYP, "asynInt32")
+  field(DESC, "Reset Clock Locked Latches")
+  field(OUT,"@asyn($(PORT))STA_LOCKED_RST_LATCH")
+  field(MASK, "1")
+  field(HIGH, "1")
+  field(ZNAM, "nothing")
+  field(ONAM, "reset")
 }
 
 record(bo, "$(P)$(R)DevEnbl-Sel"){


### PR DESCRIPTION
Since we'd be defining multiple enums with the same labels and severities for each value, using readEnum to configure them requires fewer lines of code and avoids repetition.

Depends on https://github.com/lnls-dig/uhal/pull/26