### PR TITLE
rtmlamp: fix name of CurrLoop integrative gain.

### DIFF
--- a/utcaApp/Db/rtmlamp_channel.req
+++ b/utcaApp/Db/rtmlamp_channel.req
@@ -1,5 +1,5 @@
 $(S)$(RTM_CHAN)CurrLoopKp-SP
-$(S)$(RTM_CHAN)CurrLoopTi-SP
+$(S)$(RTM_CHAN)CurrLoopKi-SP
 $(S)$(RTM_CHAN)CurrGain-SP
 $(S)$(RTM_CHAN)CurrOffset-SP
 $(S)$(RTM_CHAN)VoltGain-SP

--- a/utcaApp/Db/rtmlamp_channel.template
+++ b/utcaApp/Db/rtmlamp_channel.template
@@ -94,18 +94,18 @@ record(longin,"$(S)$(RTM_CHAN)CurrLoopKp-RB"){
     field(INP,"@asyn($(PORT),$(ADDR))PI_KP")
 }
 
-record(longout,"$(S)$(RTM_CHAN)CurrLoopTi-SP"){
+record(longout,"$(S)$(RTM_CHAN)CurrLoopKi-SP"){
     field(DTYP,"asynInt32")
-    field(DESC,"set PI Ti parameter")
+    field(DESC,"set PI Ki parameter")
     field(SCAN,"Passive")
     field(OUT,"@asyn($(PORT),$(ADDR))PI_TI")
     field(PINI,"YES")
     field(DRVH,"67108863")
     field(DRVL,"0")
 }
-record(longin,"$(S)$(RTM_CHAN)CurrLoopTi-RB"){
+record(longin,"$(S)$(RTM_CHAN)CurrLoopKi-RB"){
     field(DTYP,"asynInt32")
-    field(DESC,"get PI Ti parameter")
+    field(DESC,"get PI Ki parameter")
     field(SCAN,"I/O Intr")
     field(INP,"@asyn($(PORT),$(ADDR))PI_TI")
 }


### PR DESCRIPTION
This name should have been Ki from the start, it was named Ti mistakenly and that was propagated across the software stack. Since the underlying layers have yet to be changed, only the PV name is fixed for now.