### PR TITLE
service: use default user group.

### DIFF
--- a/service/afc-ioc@.service
+++ b/service/afc-ioc@.service
@@ -3,7 +3,6 @@ Description=AFC EPICS IOC %i
 
 [Service]
 User=iocs
-Group=iocs
 
 MemoryAccounting=yes
 


### PR DESCRIPTION
In the new installation, `iocs` user does not [belong to a dedicated `iocs` group][1], preventing the service to run. Let systemd choose the default group instead.

[1]: https://github.com/lnls-dig/bpm-cfg/blob/5065962625a1d14707bb0a6f06c88bf0412b62e9/02-cpu-configure/cpu-configure.sh#L38