### PR TITLE
service: start RFFE IOC along with BPMs.

### DIFF
--- a/service/ioc-start.sh
+++ b/service/ioc-start.sh
@@ -12,8 +12,25 @@ for slot in /sys/bus/pci/slots/* ; do
     fi
 done
 
+start_afc_ioc=false
+
 case "$(decode-reg build_info -q --slot ${devslot})" in
-    afc-tim-receive*|afcv4_fofb_ctrl*|pbpm-gw*|bpm-gw*)
-        systemctl restart afc-ioc@${devslot}.service
+    afc-tim-receive*|afcv4_fofb_ctrl*|pbpm-gw*)
+        start_afc_ioc=true
+        ;;
+    bpm-gw*)
+        start_afc_ioc=true
+
+        VSLOT1=$(/opt/afc-epics-ioc/iocBoot/iocutca/getSlot.sh $devslot)
+        VSLOT2=$(( VSLOT1 + 1 ))
+
+        services="rffe-ioc@${VSLOT1}.service"
+        [ "$VSLOT2" -lt 24 ] && services="$services rffe-ioc@${VSLOT2}.service"
+
+        systemctl start $services || true
         ;;
 esac
+
+if $start_afc_ioc; then
+    systemctl restart afc-ioc@${devslot}.service
+fi


### PR DESCRIPTION
Whenever a BPM board is detected, both AFC IOC and RFFE IOC should get up and running automatically. Since there are two core that depend on RFFE's output for each board, start two RFFE IOC services based on their virtual slots.