### PR TITLE
utcaApp: remove usage of sentinel parameters.

### DIFF
--- a/utcaApp/src/afc_timing.cpp
+++ b/utcaApp/src/afc_timing.cpp
@@ -56,7 +56,7 @@ class AFCTiming: public UDriver {
               {"CH_POL", p_decoder_controller},
               {"CH_LOG", p_decoder_controller},
               {"CH_ITL", p_decoder_controller},
-              {"CH_SRC", p_ch_src},
+              ParamInit{"CH_SRC", p_ch_src}.set_dc(),
               {"CH_DIR", p_decoder_controller},
               {"CH_PULSES", p_decoder_controller},
               ParamInit{"CH_COUNT_RST", p_decoder_controller}.set_wo(),
@@ -71,8 +71,6 @@ class AFCTiming: public UDriver {
         auto v = find_device(port_number);
         dec.set_devinfo(v);
         ctl.set_devinfo(v);
-
-        parameter_props.at(p_ch_src).write_decoder_controller = true;
 
         createParam("FREQ", asynParamFloat64, &p_freq);
 

--- a/utcaApp/src/fmcpico1m_4ch.cpp
+++ b/utcaApp/src/fmcpico1m_4ch.cpp
@@ -20,7 +20,7 @@ class FMCPico: public UDriver {
           ::number_of_channels,
           { },
           {
-              {"RANGE", p_range},
+              ParamInit{"RANGE", p_range}.set_dc(),
           },
           &ctl),
       dec(bars),
@@ -29,8 +29,6 @@ class FMCPico: public UDriver {
         auto v = find_device(port_number);
         dec.set_devinfo(v);
         ctl.set_devinfo(v);
-
-        parameter_props.at(p_range).write_decoder_controller = true;
 
         read_parameters();
     }

--- a/utcaApp/src/rtmlamp.cpp
+++ b/utcaApp/src/rtmlamp.cpp
@@ -29,7 +29,7 @@ class RtmLamp: public UDriver {
               {"AMP_STATUS", p_read_only},
               {"AMP_STATUS_LATCH", p_read_only},
               {"AMP_EN", p_decoder_controller},
-              {"MODE", p_mode},
+              ParamInit{"MODE", p_mode}.set_dc(),
               {"TRIG_EN", p_decoder_controller},
               {"RST_LATCH", p_decoder_controller},
               {"PI_KP", p_decoder_controller},
@@ -50,8 +50,6 @@ class RtmLamp: public UDriver {
         auto v = find_device(port_number);
         dec.set_devinfo(v);
         ctl.set_devinfo(v);
-
-        parameter_props.at(p_mode).write_decoder_controller = true;
 
         read_parameters();
     }


### PR DESCRIPTION
This is a code cleanup, to avoid having to expose
UDriver::parameter_props to specific drivers.

The cleanup moves all handling of special cases (decoder_controller and read_only) into the ParamInit class, instead of requiring passing UDriver static inline members to it. This allowed us to add a ParamInit::set_dc() function, which is now used by the drivers which previously had to access parameter_props directly. This also simplifies the UDriver constructor, since it can now determine the need for p_tmp more easily, as well as the parameter properties.

It also allowed us to add more sanity checks, in this case to UDriver::writeGeneral(), to report writes into read-only parameters.

---

As suggested by Henrique in https://github.com/lnls-dig/afc-epics-ioc/pull/45#discussion_r1816771699

@gustavosr8