### PR TITLE
afc_timing: add new upstream debug records.

### DIFF
--- a/build/docker-compose.yml
+++ b/build/docker-compose.yml
@@ -9,4 +9,4 @@ services:
     command: bash -c "build/uhal.sh && lnls-build-static-ioc afc-epics-ioc"
     environment:
       SKIP_CLEAN: 1
-      UHAL_VERSION: v0.9.1
+      UHAL_VERSION: v0.10.0

--- a/build/uhal.sh
+++ b/build/uhal.sh
@@ -14,7 +14,7 @@ cd /tmp/uhal
 git checkout $UHAL_VERSION
 
 if [ ! -d build/ ]; then
-	LDFLAGS=-static meson setup --buildtype debugoptimized -Dpcie_opt=true build/
+	LDFLAGS=-static meson setup --buildtype debugoptimized -Dpcie_opt=true -Dbuild-tests=false build/
 fi
 
 samu -C build/

--- a/utcaApp/Db/afc_timing.template
+++ b/utcaApp/Db/afc_timing.template
@@ -141,3 +141,91 @@ record(longin, "$(P)$(R)Alive-Mon"){
     field(INP,"@asyn($(PORT))ALIVE")
     field(SCAN,"I/O Intr")
 }
+
+record(bo, "$(P)$(R)UpstreamDebugEn-Sel"){
+    field(DTYP, "asynInt32")
+    field(DESC, "Enable upstream debug")
+    field(PINI, YES)
+    field(ZNAM, "Dsbl")
+    field(ONAM, "Enbl")
+    field(OUT, "@asyn($(PORT))DBG_EN")
+}
+record(bi, "$(P)$(R)UpstreamDebugEn-Sts"){
+    field(DTYP, "asynInt32")
+    field(DESC, "Enable upstream debug")
+    field(PINI, YES)
+    field(ZNAM, "Dsbl")
+    field(ONAM, "Enbl")
+    field(INP, "@asyn($(PORT))DBG_EN")
+    field(SCAN, "I/O Intr")
+}
+
+record(bo, "$(P)$(R)UpstreamDebugCounterRst-Cmd"){
+    field(DTYP, "asynInt32")
+    field(DESC, "Reset debug counter")
+    field(OUT, "@asyn($(PORT))DBG_COUNTER_RST")
+    field(PINI, YES)
+    field(MASK, 1)
+    field(HIGH, 1)
+    field(ZNAM, nothing)
+    field(ONAM, reset)
+}
+
+record(longout, "$(P)$(R)UpstreamDebugEvtIn-SP"){
+    field(DTYP, "asynInt32")
+    field(DESC, "Downstream start event")
+    field(PINI, YES)
+    field(OUT, "@asyn($(PORT))DBG_EVT_DS_START")
+}
+record(longin, "$(P)$(R)UpstreamDebugEvtIn-RB"){
+    field(DTYP, "asynInt32")
+    field(DESC, "Downstream start event")
+    field(INP, "@asyn($(PORT))DBG_EVT_DS_START")
+    field(SCAN, "I/O Intr")
+}
+
+record(longout, "$(P)$(R)UpstreamDebugEvtOut-SP"){
+    field(DTYP, "asynInt32")
+    field(DESC, "Upstream event")
+    field(PINI, YES)
+    field(OUT, "@asyn($(PORT))DBG_EVT_US")
+}
+record(longin, "$(P)$(R)UpstreamDebugEvtOut-RB"){
+    field(DTYP, "asynInt32")
+    field(DESC, "Upstream event")
+    field(INP, "@asyn($(PORT))DBG_EVT_US")
+    field(SCAN, "I/O Intr")
+}
+
+record(longout, "$(P)$(R)UpstreamDebugSpacing-SP"){
+    field(DTYP, "asynInt32")
+    field(DESC, "Spacing between upstream events")
+    field(PINI, YES)
+    field(OUT, "@asyn($(PORT))DBG_EVT_SPACING")
+}
+record(longin, "$(P)$(R)UpstreamDebugSpacing-RB"){
+    field(DTYP, "asynInt32")
+    field(DESC, "Spacing between upstream events")
+    field(INP, "@asyn($(PORT))DBG_EVT_SPACING")
+    field(SCAN, "I/O Intr")
+}
+
+record(longout, "$(P)$(R)UpstreamDebugReps-SP"){
+    field(DTYP, "asynInt32")
+    field(DESC, "Upstream event repetitions")
+    field(PINI, YES)
+    field(OUT, "@asyn($(PORT))DBG_EVT_REPS")
+}
+record(longin, "$(P)$(R)UpstreamDebugReps-RB"){
+    field(DTYP, "asynInt32")
+    field(DESC, "Upstream event repetitions")
+    field(INP, "@asyn($(PORT))DBG_EVT_REPS")
+    field(SCAN, "I/O Intr")
+}
+
+record(longin, "$(P)$(R)UpstreamDebugCounter-Mon"){
+    field(DTYP, "asynInt32")
+    field(DESC, "Debug procedure counter")
+    field(INP, "@asyn($(PORT))DBG_COUNTER")
+    field(SCAN, "I/O Intr")
+}

--- a/utcaApp/src/afc_timing.cpp
+++ b/utcaApp/src/afc_timing.cpp
@@ -39,6 +39,13 @@ class AFCTiming: public UDriver {
               {"LOCKED_GT0_LTC", p_last_lock},
               {"ALIVE", p_read_only},
               ParamInit{"RST_LOCKED_LTCS", p_decoder_controller}.set_wo(),
+              {"DBG_EN", p_decoder_controller},
+              ParamInit{"DBG_COUNTER_RST", p_decoder_controller}.set_wo(),
+              {"DBG_EVT_DS_START", p_decoder_controller},
+              {"DBG_EVT_US", p_decoder_controller},
+              {"DBG_EVT_SPACING", p_decoder_controller},
+              {"DBG_EVT_REPS", p_decoder_controller},
+              {"DBG_COUNTER", p_read_only},
           },
           {
               ParamInit{"RFREQ_HI", p_read_only}.set_nc(2),


### PR DESCRIPTION
Depends on https://github.com/lnls-dig/uhal/pull/59

@anacso17 could you take a look to confirm we are using good PV names? We should also add checking to the high level orbit interlock to ensure UpstreamDebugEn-Sts is zero, because it interferes with the orbit interlock upstream event.

Draft pending on coordinating changes to HL orbit interlock