### PR TITLE
service: attempt a reset when no SDB can be found.

### DIFF
--- a/service/ioc-start.sh
+++ b/service/ioc-start.sh
@@ -14,7 +14,13 @@ done
 
 start_afc_ioc=false
 
-case "$(decode-reg build_info -q --slot ${devslot})" in
+synthesis="$(decode-reg build_info -q --slot ${devslot})"
+if [ -z "$synthesis" ]; then
+    decode-reg reset --slot ${devslot}
+    synthesis="$(decode-reg build_info -q --slot ${devslot})"
+fi
+
+case "$synthesis" in
     afc-tim-receive*|afcv4_fofb_ctrl*|pbpm-gw*)
         start_afc_ioc=true
         ;;


### PR DESCRIPTION
In some conditions, reading from BAR4 will return only 1s, so the SDB can't even be accessed in order to be decoded. For some of these situations, resetting the PCIe interface via BAR0 restores BAR4 functionality.

The effects of this reset aren't fully understood, but, since any further steps to restore communication with the board would include removing the PCIe slot or restarting the board, any side-effects are considered benign.