### PR TITLE
service: prevent dbCa connection issues.

### DIFF
--- a/service/afc-ioc@.service
+++ b/service/afc-ioc@.service
@@ -1,5 +1,7 @@
 [Unit]
 Description=AFC EPICS IOC %i
+After=network-online.target
+Wants=network-online.target
 
 [Service]
 User=iocs


### PR DESCRIPTION
As reported in rffe-epics-ioc [1] commit 47deaff (service: fix asCa connection issues., 2026-03-09), it's necessary to wait for network configuration [2] before starting an IOC if it depends on external PVs. The timing IOC depends on external PVs in a rarely used path, which could explain why we never noticed anything. It could also be related to the time that record initialization takes, so network interfaces manage to come up before the IOC's CA client.

The implementation follows the example service [3].

[1] https://github.com/lnls-dig/rffe-epics-ioc
[2] https://epics.anl.gov/tech-talk/2026/msg00340.php
[3] https://github.com/NSLS2/systemd-softioc/blob/master/softioc-example.service

---

@gustavosr8